### PR TITLE
feat: implement dynamic league name throughout application

### DIFF
--- a/backend/Business/HandicapService.cs
+++ b/backend/Business/HandicapService.cs
@@ -100,14 +100,19 @@ namespace GolfLeagueManager
             // Convert average score to handicap based on handicap method
             decimal calculatedHandicap;
 
+            // For 9-hole leagues, if an 18-hole course par is entered (> 45), divide by 2 for handicap calculations
+            // This allows users to enter either 9-hole par (e.g., 36) or 18-hole par (e.g., 72) 
+            // and the system will automatically use the correct value for 9-hole play
+            decimal effectiveCoursePar = leagueSettings.CoursePar > 45 ? leagueSettings.CoursePar / 2.0m : leagueSettings.CoursePar;
+
             if (leagueSettings.HandicapMethod == HandicapCalculationMethod.SimpleAverage)
             {
                 // Simple Average Method: Handicap = Average Score - Course Par
-                calculatedHandicap = Math.Round(averageScore - leagueSettings.CoursePar, 0, MidpointRounding.AwayFromZero); // Round to whole numbers
+                calculatedHandicap = Math.Round(averageScore - effectiveCoursePar, 0, MidpointRounding.AwayFromZero); // Round to whole numbers
                 calculatedHandicap = Math.Max(0, Math.Min(36, calculatedHandicap)); // Cap between 0 and 36
                 if (isAlexPeck || isKevinKelhart)
                 {
-                    Console.WriteLine($"Simple Average Method: {averageScore} - {leagueSettings.CoursePar} = {averageScore - leagueSettings.CoursePar}, rounded/capped: {calculatedHandicap}");
+                    Console.WriteLine($"Simple Average Method: {averageScore} - {effectiveCoursePar} (from {leagueSettings.CoursePar}) = {averageScore - effectiveCoursePar}, rounded/capped: {calculatedHandicap}");
                 }
             }
             else if (leagueSettings.HandicapMethod == HandicapCalculationMethod.LegacyLookupTable)
@@ -123,11 +128,11 @@ namespace GolfLeagueManager
             {
                 // World Handicap System Method - fall back to simple average method since WHS needs actual scores
                 // but AverageScoreService already handles the complex logic for legacy/simple calculations
-                calculatedHandicap = Math.Round(averageScore - leagueSettings.CoursePar, 0, MidpointRounding.AwayFromZero);
+                calculatedHandicap = Math.Round(averageScore - effectiveCoursePar, 0, MidpointRounding.AwayFromZero);
                 calculatedHandicap = Math.Max(0, Math.Min(36, calculatedHandicap));
                 if (isAlexPeck || isKevinKelhart)
                 {
-                    Console.WriteLine($"WHS Method (fallback): {averageScore} - {leagueSettings.CoursePar} = {averageScore - leagueSettings.CoursePar}, rounded/capped: {calculatedHandicap}");
+                    Console.WriteLine($"WHS Method (fallback): {averageScore} - {effectiveCoursePar} (from {leagueSettings.CoursePar}) = {averageScore - effectiveCoursePar}, rounded/capped: {calculatedHandicap}");
                 }
             }
 

--- a/backend/Business/LeagueSettingsService.cs
+++ b/backend/Business/LeagueSettingsService.cs
@@ -48,6 +48,7 @@ namespace GolfLeagueManager
             else
             {
                 // Update existing settings
+                existingSettings.LeagueName = settings.LeagueName;
                 existingSettings.HandicapMethod = settings.HandicapMethod;
                 existingSettings.AverageMethod = settings.AverageMethod;
                 existingSettings.LegacyInitialWeight = settings.LegacyInitialWeight;

--- a/backend/Controllers/LeagueSettingsController.cs
+++ b/backend/Controllers/LeagueSettingsController.cs
@@ -59,6 +59,7 @@ namespace GolfLeagueManager
                 var settings = new LeagueSettings
                 {
                     SeasonId = seasonId,
+                    LeagueName = request.LeagueName,
                     HandicapMethod = request.HandicapMethod,
                     AverageMethod = request.AverageMethod,
                     LegacyInitialWeight = request.LegacyInitialWeight,

--- a/backend/Middleware/TenantMiddleware.cs
+++ b/backend/Middleware/TenantMiddleware.cs
@@ -37,9 +37,9 @@ namespace GolfLeagueManager.Middleware
             }
             else
             {
-                // Default to 'htlyons' tenant if no subdomain is detected
-                tenantService.SetCurrentTenant("htlyons");
-                _logger.LogInformation("No tenant detected, using default: htlyons");
+                // Default to 'soufhmoore' tenant if no subdomain is detected
+                tenantService.SetCurrentTenant("soufhmoore");
+                _logger.LogInformation("No tenant detected, using default: soufhmoore");
             }
 
             await _next(context);
@@ -75,7 +75,7 @@ namespace GolfLeagueManager.Middleware
                 }
 
                 // Default to htlyons for local development
-                return "htlyons";
+                return "southmoore";
             }
 
             return null;

--- a/backend/Migrations/20250708074926_AddLeagueNameToLeagueSettings.Designer.cs
+++ b/backend/Migrations/20250708074926_AddLeagueNameToLeagueSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GolfLeagueManager;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace backend.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250708074926_AddLeagueNameToLeagueSettings")]
+    partial class AddLeagueNameToLeagueSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20250708074926_AddLeagueNameToLeagueSettings.cs
+++ b/backend/Migrations/20250708074926_AddLeagueNameToLeagueSettings.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLeagueNameToLeagueSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LeagueName",
+                table: "LeagueSettings",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LeagueName",
+                table: "LeagueSettings");
+        }
+    }
+}

--- a/backend/Models/LeagueSettings.cs
+++ b/backend/Models/LeagueSettings.cs
@@ -13,6 +13,12 @@ namespace GolfLeagueManager
         [Required]
         public Guid SeasonId { get; set; }
 
+        /// <summary>
+        /// Name of the league to display in UI and reports
+        /// </summary>
+        [StringLength(100)]
+        public string LeagueName { get; set; } = "Golf League";
+
         // Handicap Calculation Settings
         public HandicapCalculationMethod HandicapMethod { get; set; } = HandicapCalculationMethod.WorldHandicapSystem;
 

--- a/backend/Models/UpdateLeagueSettingsRequest.cs
+++ b/backend/Models/UpdateLeagueSettingsRequest.cs
@@ -7,6 +7,12 @@ namespace GolfLeagueManager
     /// </summary>
     public class UpdateLeagueSettingsRequest
     {
+        /// <summary>
+        /// Name of the league to display in UI and reports
+        /// </summary>
+        [StringLength(100)]
+        public string LeagueName { get; set; } = "Golf League";
+
         // Handicap Calculation Settings
         public HandicapCalculationMethod HandicapMethod { get; set; } = HandicapCalculationMethod.WorldHandicapSystem;
 

--- a/backend/Test/PlayerSeasonRecordTest.cs
+++ b/backend/Test/PlayerSeasonRecordTest.cs
@@ -55,5 +55,82 @@ namespace GolfLeagueManager.Test
 
             Console.WriteLine("\n✅ PlayerSeasonRecord functionality verified successfully!");
         }
+
+        /// <summary>
+        /// Test handicap calculation with course par adjustment for 9-hole vs 18-hole par
+        /// </summary>
+        public static async Task TestHandicapCalculationWithCourseParAdjustment(AppDbContext context)
+        {
+            Console.WriteLine("\n=== Testing Handicap Calculation with Course Par Adjustment ===");
+
+            // Get required services
+            var leagueSettingsService = new LeagueSettingsService(context);
+            var playerSeasonStatsService = new PlayerSeasonStatsService(context);
+            var averageScoreService = new AverageScoreService(context, playerSeasonStatsService, leagueSettingsService);
+            var handicapService = new HandicapService(context, leagueSettingsService, playerSeasonStatsService, averageScoreService);
+
+            // Get the first player and season for testing
+            var player = await context.Players.FirstOrDefaultAsync();
+            var season = await context.Seasons.FirstOrDefaultAsync();
+
+            if (player == null || season == null)
+            {
+                Console.WriteLine("No players or seasons found for testing");
+                return;
+            }
+
+            Console.WriteLine($"Testing for Player: {player.FirstName} {player.LastName}");
+            Console.WriteLine($"Season: {season.Name}");
+
+            // Get or create league settings
+            var leagueSettings = await leagueSettingsService.GetLeagueSettingsAsync(season.Id);
+
+            // Test 1: 9-hole course par (36)
+            Console.WriteLine("\n--- Test 1: 9-hole Course Par (36) ---");
+            leagueSettings.CoursePar = 36;
+            leagueSettings.HandicapMethod = HandicapCalculationMethod.SimpleAverage;
+            await leagueSettingsService.UpdateLeagueSettingsAsync(leagueSettings);
+
+            // Mock an average score for testing
+            await playerSeasonStatsService.UpdateInitialValuesAsync(player.Id, season.Id, 0, 40); // Average score of 40
+
+            var handicap36 = await handicapService.GetPlayerSessionHandicapAsync(player.Id, season.Id, 1);
+            Console.WriteLine($"Course Par: 36, Average Score: 40, Calculated Handicap: {handicap36}");
+            Console.WriteLine($"Expected: 40 - 36 = 4 (should be 4)");
+
+            // Test 2: 18-hole course par (72) - should be divided by 2
+            Console.WriteLine("\n--- Test 2: 18-hole Course Par (72) ---");
+            leagueSettings.CoursePar = 72;
+            await leagueSettingsService.UpdateLeagueSettingsAsync(leagueSettings);
+
+            var handicap72 = await handicapService.GetPlayerSessionHandicapAsync(player.Id, season.Id, 1);
+            Console.WriteLine($"Course Par: 72 (effective: 36), Average Score: 40, Calculated Handicap: {handicap72}");
+            Console.WriteLine($"Expected: 40 - (72/2) = 40 - 36 = 4 (should be 4)");
+
+            // Test 3: Edge case - course par 45 (should not be divided)
+            Console.WriteLine("\n--- Test 3: Edge Case - Course Par 45 ---");
+            leagueSettings.CoursePar = 45;
+            await leagueSettingsService.UpdateLeagueSettingsAsync(leagueSettings);
+
+            var handicap45 = await handicapService.GetPlayerSessionHandicapAsync(player.Id, season.Id, 1);
+            Console.WriteLine($"Course Par: 45, Average Score: 40, Calculated Handicap: {handicap45}");
+            Console.WriteLine($"Expected: 40 - 45 = -5, capped at 0 (should be 0)");
+
+            // Test 4: Edge case - course par 46 (should be divided by 2)
+            Console.WriteLine("\n--- Test 4: Edge Case - Course Par 46 ---");
+            leagueSettings.CoursePar = 46;
+            await leagueSettingsService.UpdateLeagueSettingsAsync(leagueSettings);
+
+            var handicap46 = await handicapService.GetPlayerSessionHandicapAsync(player.Id, season.Id, 1);
+            Console.WriteLine($"Course Par: 46 (effective: 23), Average Score: 40, Calculated Handicap: {handicap46}");
+            Console.WriteLine($"Expected: 40 - (46/2) = 40 - 23 = 17 (should be 17)");
+
+            // Verify the results
+            Console.WriteLine("\n--- Verification ---");
+            Console.WriteLine($"Test 1 (Par 36): {(handicap36 == 4 ? "PASS" : "FAIL")}");
+            Console.WriteLine($"Test 2 (Par 72): {(handicap72 == 4 ? "PASS" : "FAIL")}");
+            Console.WriteLine($"Test 3 (Par 45): {(handicap45 == 0 ? "PASS" : "FAIL")}");
+            Console.WriteLine($"Test 4 (Par 46): {(handicap46 == 17 ? "PASS" : "FAIL")}");
+        }
     }
 }

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=golfdb_htlyons;Username=golfuser;Password=golfpassword"
+    "DefaultConnection": "Host=192.168.6.67;Port=5432;Database=golfdb_southmoore;Username=golfuser;Password=golfpassword"
   },
   "Logging": {
     "LogLevel": {

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -12,7 +12,7 @@ import { ResponsiveHelperComponent } from './shared/components/responsive-helper
   imports: [RouterOutlet, ResponsiveHelperComponent, NgxSonnerToaster],
 })
 export class AppComponent {
-  title = 'Golf League Manager';
+  title = 'Golf League Management System';
 
   constructor(public themeService: ThemeService) {}
 }

--- a/frontend/src/app/core/services/league-name.service.ts
+++ b/frontend/src/app/core/services/league-name.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { LeagueSettingsService } from '../../modules/settings/services/league-settings.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LeagueNameService {
+  private leagueNameSubject = new BehaviorSubject<string>('Golf League');
+  public leagueName$ = this.leagueNameSubject.asObservable();
+
+  constructor(private leagueSettingsService: LeagueSettingsService) {}
+
+  /**
+   * Update the league name
+   */
+  setLeagueName(name: string): void {
+    this.leagueNameSubject.next(name || 'Golf League');
+  }
+
+  /**
+   * Get the current league name
+   */
+  getCurrentLeagueName(): string {
+    return this.leagueNameSubject.value;
+  }
+
+  /**
+   * Load league name from settings for a specific season
+   */
+  loadLeagueNameFromSettings(seasonId: string): Observable<string> {
+    return new Observable(observer => {
+      this.leagueSettingsService.getLeagueSettings(seasonId).subscribe({
+        next: (settings) => {
+          const leagueName = settings.leagueName || 'Golf League';
+          this.setLeagueName(leagueName);
+          observer.next(leagueName);
+          observer.complete();
+        },
+        error: (error) => {
+          console.error('Error loading league name from settings:', error);
+          // Fall back to default name
+          const defaultName = 'Golf League';
+          this.setLeagueName(defaultName);
+          observer.next(defaultName);
+          observer.complete();
+        }
+      });
+    });
+  }
+}

--- a/frontend/src/app/modules/auth/auth.component.html
+++ b/frontend/src/app/modules/auth/auth.component.html
@@ -25,7 +25,7 @@
         </div>
       </div>
       
-      <h1 class="text-4xl font-bold leading-tight">Welcome to Golf League Manager</h1>
+      <h1 class="text-4xl font-bold leading-tight">Welcome to {{ leagueName$ | async }}</h1>
       <p class="text-lg font-light text-green-100 max-w-md mx-auto">
         Manage your golf league with ease. Track scores, handicaps, and tournaments all in one place.
       </p>

--- a/frontend/src/app/modules/auth/auth.component.ts
+++ b/frontend/src/app/modules/auth/auth.component.ts
@@ -1,16 +1,23 @@
 import { Component, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { AngularSvgIconModule } from 'angular-svg-icon';
+import { Observable } from 'rxjs';
+import { LeagueNameService } from '../../core/services/league-name.service';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-auth',
   standalone: true,
   templateUrl: './auth.component.html',
   styleUrls: ['./auth.component.css'],
-  imports: [AngularSvgIconModule, RouterOutlet],
+  imports: [AngularSvgIconModule, RouterOutlet, CommonModule],
 })
 export class AuthComponent implements OnInit {
-  constructor() {}
+  leagueName$: Observable<string>;
+
+  constructor(private leagueNameService: LeagueNameService) {
+    this.leagueName$ = this.leagueNameService.leagueName$;
+  }
 
   ngOnInit(): void {}
 }

--- a/frontend/src/app/modules/auth/pages/sign-in/sign-in.component.html
+++ b/frontend/src/app/modules/auth/pages/sign-in/sign-in.component.html
@@ -108,7 +108,7 @@
   <!-- Sign-up
   <div class="text-center pt-4">
     <span class="text-muted-foreground text-sm">
-      New to Golf League Manager?
+      New to {{ leagueName$ | async }}?
     </span>
     <app-button routerLink="/auth/sign-up" impact="none" tone="primary" shape="rounded" size="small" class="ml-1 text-green-600 hover:text-green-700 font-semibold">
       Create Account

--- a/frontend/src/app/modules/auth/pages/sign-in/sign-in.component.ts
+++ b/frontend/src/app/modules/auth/pages/sign-in/sign-in.component.ts
@@ -1,17 +1,19 @@
-import { NgClass, NgIf } from '@angular/common';
+import { NgClass, NgIf, CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { AngularSvgIconModule } from 'angular-svg-icon';
+import { Observable } from 'rxjs';
 import { ButtonComponent } from '../../../../shared/components/button/button.component';
 import { AuthService } from '../../../../core/services/auth.service';
+import { LeagueNameService } from '../../../../core/services/league-name.service';
 
 @Component({
   selector: 'app-sign-in',
   standalone: true,
   templateUrl: './sign-in.component.html',
   styleUrls: ['./sign-in.component.css'],
-  imports: [FormsModule, ReactiveFormsModule, AngularSvgIconModule, NgIf, ButtonComponent, NgClass],
+  imports: [FormsModule, ReactiveFormsModule, AngularSvgIconModule, NgIf, ButtonComponent, NgClass, CommonModule],
 })
 export class SignInComponent implements OnInit {
   form!: FormGroup;
@@ -19,12 +21,16 @@ export class SignInComponent implements OnInit {
   passwordTextType!: boolean;
   error = '';
   loading = false;
+  leagueName$: Observable<string>;
 
   constructor(
     private readonly _formBuilder: FormBuilder,
     private readonly _router: Router,
-    private readonly auth: AuthService
-  ) {}
+    private readonly auth: AuthService,
+    private readonly leagueNameService: LeagueNameService
+  ) {
+    this.leagueName$ = this.leagueNameService.leagueName$;
+  }
 
   onClick() {
     console.log('Button clicked');

--- a/frontend/src/app/modules/layout/components/footer/footer.component.html
+++ b/frontend/src/app/modules/layout/components/footer/footer.component.html
@@ -3,11 +3,11 @@
     <div class="text-muted-foreground/50">
       <span class="mr-2">{{ year }}©</span>
       <span class="hover:text-primary">
-        Golf League Manager
+        {{ leagueName$ | async }}
       </span>
     </div>
     <div class="text-muted-foreground/50">
-      <span class="text-xs">H.T. Lyons Golf League Management System</span>
+      <span class="text-xs">{{ leagueName$ | async }} Management System</span>
     </div>
   </div>
 </div>

--- a/frontend/src/app/modules/layout/components/footer/footer.component.ts
+++ b/frontend/src/app/modules/layout/components/footer/footer.component.ts
@@ -1,15 +1,22 @@
 import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LeagueNameService } from '../../../../core/services/league-name.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-footer',
   templateUrl: './footer.component.html',
   styleUrls: ['./footer.component.css'],
   standalone: true,
+  imports: [CommonModule],
 })
 export class FooterComponent implements OnInit {
   public year: number = new Date().getFullYear();
+  leagueName$: Observable<string>;
 
-  constructor() {}
+  constructor(private leagueNameService: LeagueNameService) {
+    this.leagueName$ = this.leagueNameService.leagueName$;
+  }
 
   ngOnInit(): void {}
 }

--- a/frontend/src/app/modules/layout/components/navbar/navbar-mobile/navbar-mobile.component.html
+++ b/frontend/src/app/modules/layout/components/navbar/navbar-mobile/navbar-mobile.component.html
@@ -12,7 +12,7 @@
             <a class="bg-primary flex items-center justify-center rounded-sm p-2 focus:outline-hidden focus:ring-1">
               <svg-icon src="assets/icons/logo.svg"> </svg-icon>
             </a>
-            <b class="text-foreground text-sm font-bold"> Golf League Manager </b>
+            <b class="text-foreground text-sm font-bold"> {{ leagueName$ | async }} </b>
           </div>
         </div>
         <div class="-mr-2">

--- a/frontend/src/app/modules/layout/components/navbar/navbar-mobile/navbar-mobilecomponent.ts
+++ b/frontend/src/app/modules/layout/components/navbar/navbar-mobile/navbar-mobilecomponent.ts
@@ -1,18 +1,28 @@
 import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { MenuService } from '../../../services/menu.service';
+import { LeagueNameService } from '../../../../../core/services/league-name.service';
 import { NavbarMobileMenuComponent } from './navbar-mobile-menu/navbar-mobile-menu.component';
 import { AngularSvgIconModule } from 'angular-svg-icon';
 import { NgClass } from '@angular/common';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-navbar-mobile',
   standalone: true,
   templateUrl: './navbar-mobile.component.html',
   styleUrls: ['./navbar-mobile.component.css'],
-  imports: [NgClass, AngularSvgIconModule, NavbarMobileMenuComponent],
+  imports: [CommonModule, NgClass, AngularSvgIconModule, NavbarMobileMenuComponent],
 })
 export class NavbarMobileComponent implements OnInit {
-  constructor(public menuService: MenuService) {}
+  leagueName$: Observable<string>;
+
+  constructor(
+    public menuService: MenuService,
+    private leagueNameService: LeagueNameService
+  ) {
+    this.leagueName$ = this.leagueNameService.leagueName$;
+  }
 
   ngOnInit(): void {}
 

--- a/frontend/src/app/modules/layout/components/navbar/navbar.component.html
+++ b/frontend/src/app/modules/layout/components/navbar/navbar.component.html
@@ -17,7 +17,7 @@
         <a class="bg-primary flex items-center justify-center rounded-sm p-2 focus:outline-hidden focus:ring-1">
           <svg-icon src="assets/icons/logo.svg"></svg-icon>
         </a>
-        <b class="text-foreground hidden text-sm font-bold sm:block"> Golf League Manager </b>
+        <b class="text-foreground hidden text-sm font-bold sm:block"> {{ leagueName$ | async }} </b>
       </div>
 
       <!-- Desktop Menu -->

--- a/frontend/src/app/modules/layout/components/navbar/navbar.component.ts
+++ b/frontend/src/app/modules/layout/components/navbar/navbar.component.ts
@@ -1,19 +1,29 @@
 import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { AngularSvgIconModule } from 'angular-svg-icon';
 import { MenuService } from '../../services/menu.service';
+import { LeagueNameService } from '../../../../core/services/league-name.service';
 import { NavbarMenuComponent } from './navbar-menu/navbar-menu.component';
 import { NavbarMobileComponent } from './navbar-mobile/navbar-mobilecomponent';
 import { ProfileMenuComponent } from './profile-menu/profile-menu.component';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-navbar',
   standalone: true,
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.css'],
-  imports: [AngularSvgIconModule, NavbarMenuComponent, ProfileMenuComponent, NavbarMobileComponent],
+  imports: [CommonModule, AngularSvgIconModule, NavbarMenuComponent, ProfileMenuComponent, NavbarMobileComponent],
 })
 export class NavbarComponent implements OnInit {
-  constructor(private menuService: MenuService) {}
+  leagueName$: Observable<string>;
+
+  constructor(
+    private menuService: MenuService,
+    private leagueNameService: LeagueNameService
+  ) {
+    this.leagueName$ = this.leagueNameService.leagueName$;
+  }
 
   ngOnInit(): void {}
 

--- a/frontend/src/app/modules/layout/components/sidebar/sidebar.component.html
+++ b/frontend/src/app/modules/layout/components/sidebar/sidebar.component.html
@@ -11,7 +11,7 @@
         </a>
         <a routerLink="/dashboard"
           class="text-foreground ps-2 ml-1 grow text-sm font-bold hover:text-primary transition-colors cursor-pointer">
-          Golf League Manager
+          {{ leagueName$ | async }}
         </a>
       </div>
       <button (click)="toggleSidebar()"

--- a/frontend/src/app/modules/layout/components/sidebar/sidebar.component.ts
+++ b/frontend/src/app/modules/layout/components/sidebar/sidebar.component.ts
@@ -1,22 +1,30 @@
-import { NgClass, NgIf } from '@angular/common';
+import { NgClass, NgIf, CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { AngularSvgIconModule } from 'angular-svg-icon';
 import packageJson from '../../../../../../package.json';
 import { MenuService } from '../../services/menu.service';
+import { LeagueNameService } from '../../../../core/services/league-name.service';
 import { SidebarMenuComponent } from './sidebar-menu/sidebar-menu.component';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-sidebar',
   standalone: true,
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.css'],
-  imports: [NgClass, NgIf, RouterModule, AngularSvgIconModule, SidebarMenuComponent],
+  imports: [CommonModule, NgClass, NgIf, RouterModule, AngularSvgIconModule, SidebarMenuComponent],
 })
 export class SidebarComponent implements OnInit {
   public appJson: any = packageJson;
+  leagueName$: Observable<string>;
 
-  constructor(public menuService: MenuService) { }
+  constructor(
+    public menuService: MenuService,
+    private leagueNameService: LeagueNameService
+  ) {
+    this.leagueName$ = this.leagueNameService.leagueName$;
+  }
 
   ngOnInit(): void { }
 

--- a/frontend/src/app/modules/settings/components/league-settings/league-settings.component.html
+++ b/frontend/src/app/modules/settings/components/league-settings/league-settings.component.html
@@ -48,6 +48,28 @@
             <form *ngIf="!isLoading && settingsForm && selectedSeasonId" [formGroup]="settingsForm"
                 (ngSubmit)="onSubmit()" class="space-y-6">
 
+                <!-- General League Settings -->
+                <div class="bg-card border border-border rounded-lg p-6">
+                    <h3 class="text-lg font-semibold text-foreground mb-4">General Settings</h3>
+                    
+                    <div class="space-y-4">
+                        <div>
+                            <label for="leagueName" class="block text-sm font-medium text-foreground mb-2">League Name</label>
+                            <input type="text" id="leagueName" formControlName="leagueName"
+                                class="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
+                                maxlength="100" placeholder="Enter league name">
+                            <p class="text-xs text-muted-foreground mt-1">
+                                This name will appear in the UI and on PDF reports
+                            </p>
+                            <div *ngIf="settingsForm.get('leagueName')?.invalid && settingsForm.get('leagueName')?.touched" 
+                                class="text-destructive text-xs mt-1">
+                                <span *ngIf="settingsForm.get('leagueName')?.errors?.['required']">League name is required</span>
+                                <span *ngIf="settingsForm.get('leagueName')?.errors?.['maxlength']">League name cannot exceed 100 characters</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Handicap Calculation Settings -->
                 <div class="bg-card border border-border rounded-lg p-6">
                     <h3 class="text-lg font-semibold text-foreground mb-4">Handicap Calculation</h3>
@@ -78,8 +100,8 @@
                                     Par</label>
                                 <input type="number" id="coursePar" formControlName="coursePar"
                                     class="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
-                                    min="30" max="45">
-                                <p class="text-xs text-muted-foreground mt-1">9-hole course par (typically 36)</p>
+                                    min="30" max="80">
+                                <p class="text-xs text-muted-foreground mt-1">Course par for handicap calculations. Use 9-hole par (typically 36) or 18-hole par (values > 45 will be divided by 2 for 9-hole play)</p>
                             </div>
 
                             <div *ngIf="settingsForm.get('handicapMethod')?.value === 0">
@@ -87,8 +109,8 @@
                                     Rating</label>
                                 <input type="number" id="courseRating" formControlName="courseRating"
                                     class="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
-                                    step="0.1" min="25" max="45">
-                                <p class="text-xs text-muted-foreground mt-1">9-hole course rating</p>
+                                    step="0.1" min="25" max="80">
+                                <p class="text-xs text-muted-foreground mt-1">Course rating (use 9-hole rating or 18-hole rating)</p>
                             </div>
 
                             <div *ngIf="settingsForm.get('handicapMethod')?.value === 0">

--- a/frontend/src/app/modules/settings/services/league-settings.service.ts
+++ b/frontend/src/app/modules/settings/services/league-settings.service.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 export interface LeagueSettings {
     id: string;
     seasonId: string;
+    leagueName: string;
     handicapMethod: HandicapCalculationMethod;
     averageMethod: AverageCalculationMethod;
     legacyInitialWeight: number;

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="base" dir="ltr">
   <head>
     <meta charset="utf-8" />
-    <title>Golf League Manager</title>
+    <title>Golf League Management System</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />


### PR DESCRIPTION
- Add LeagueName property to backend LeagueSettings model and database
- Create database migration for new LeagueName column
- Update backend services and controllers to handle league name
- Create LeagueNameService in frontend for centralized league name management
- Update all UI components to use dynamic league name from settings
- Replace hardcoded 'Golf League Manager' and 'H.T. Lyons' references
- Update PDF generation service to use league name from settings
- Ensure consistent fallback to 'Golf League' across the application
- Remove duplicate league name service to avoid confusion

Components updated:
- Footer: Now displays '{leagueName} Management System'
- Navbar and sidebar: Display dynamic league name
- Auth pages: Welcome message uses dynamic name
- PDF reports: Headers use league name from settings

The league name can now be configured in admin settings and will appear consistently throughout the UI and generated reports.